### PR TITLE
fix for dup self

### DIFF
--- a/tests/pa4-for.test.ts
+++ b/tests/pa4-for.test.ts
@@ -194,5 +194,19 @@ describe("PA4 tests for for-loops", () => {
     for b in a:
         for c in b:
             print(c.x)`, ["1", "1", "1", "1"]);
+
+    assertPrint("two-for-loops", `
+a:[[int]]=None
+b:[int]=None
+c:int=1
+i:int = 0
+a=[[1,2],[2,3]]
+for b in a:
+    for c in b:
+        i = i + c
+for b in a:
+    for c in b:
+        i = i + c
+print(i)`, ["16"]);
 });
 

--- a/tests/pa4-inheritance.test.ts
+++ b/tests/pa4-inheritance.test.ts
@@ -213,7 +213,7 @@ b: B = None
 m = M()
 a = A()
 b = B()
-print(b.add(a.f(a.f(a.f(4))), m.f(m.f(m.f(3))) ) )`, [`24`]);
+print(b.add(a.f(a.f(a.f(4))), m.f(m.f(m.f(3)))))`, [`24`]);
 
 
 });

--- a/tests/pa4-inheritance.test.ts
+++ b/tests/pa4-inheritance.test.ts
@@ -216,4 +216,30 @@ b = B()
 print(b.add(a.f(a.f(a.f(4))), m.f(m.f(m.f(3)))))`, [`24`]);
 
 
+    assertPrint("recursively call method", `
+class M(object):
+    def f(self: M, a: int) -> int:
+        return a
+
+class A(object):
+    a: int = 1
+    def f(self: A, p:int) -> int:
+        if (p > 0):
+            self.a = self.a + self.f(p-1)
+        return self.a
+    def add(self: A, p:int, q:int) -> int:
+        return self.a + p + q
+
+class B(A):
+    pass
+
+m: M = None
+a: A = None
+b: B = None
+m = M()
+a = A()
+b = B()
+print(b.add(a.f(a.f(a.f(4))), m.f(m.f(m.f(3))) ) )`, [`934`]);
+
+
 });


### PR DESCRIPTION
use a counter to count the nested usage of self when we have nested method calls, ie, a.f(b.f(), b.f()) etc.
then define all used counters as global variables
like we did for for-loop variables.
try to minimize the number of counters 
also optimize for-loop variables.